### PR TITLE
Fix postcss config plugin name

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    '@tailwindcss/postcss': {},
+    tailwindcss: {},
     autoprefixer: {},
   },
 }


### PR DESCRIPTION
## Summary
- update postcss plugin name from `@tailwindcss/postcss` to `tailwindcss`

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d3944b60c832a8831272935d476e3