### PR TITLE
Load Tailwind via standard PostCSS plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
-        "@tailwindcss/postcss": "^4.1.11",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
@@ -1636,20 +1635,6 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/postcss": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.11.tgz",
-      "integrity": "sha512-q/EAIIpF6WpLhKEuQSEVMZNMIY8KhWoAemZ9eylNAih9jxMGAYPPWBn3I9QL/2jZ+e7OEz/tZkX5HwbBR4HohA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.1.11",
-        "@tailwindcss/oxide": "4.1.11",
-        "postcss": "^8.4.41",
-        "tailwindcss": "4.1.11"
       }
     },
     "node_modules/@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
-    "@tailwindcss/postcss": "^4.1.11",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,9 +45,6 @@ importers:
       '@eslint/js':
         specifier: ^9.30.1
         version: 9.30.1
-      '@tailwindcss/postcss':
-        specifier: ^4.1.11
-        version: 4.1.11
       '@types/react':
         specifier: ^19.1.8
         version: 19.1.8
@@ -718,9 +715,6 @@ packages:
   '@tailwindcss/oxide@4.1.11':
     resolution: {integrity: sha512-Q69XzrtAhuyfHo+5/HMgr1lAiPP/G40OMFAnws7xcFEYqcypZmdW8eGXaOUIeOl1dzPJBPENXgbjsOyhg2nkrg==}
     engines: {node: '>= 10'}
-
-  '@tailwindcss/postcss@4.1.11':
-    resolution: {integrity: sha512-q/EAIIpF6WpLhKEuQSEVMZNMIY8KhWoAemZ9eylNAih9jxMGAYPPWBn3I9QL/2jZ+e7OEz/tZkX5HwbBR4HohA==}
 
   '@ts-morph/common@0.19.0':
     resolution: {integrity: sha512-Unz/WHmd4pGax91rdIKWi51wnVUW11QttMEPpBiBgIewnc9UQIX7UDLxr5vRlqeByXCwhkF6VabSsI0raWcyAQ==}
@@ -2705,9 +2699,6 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.11
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.11
 
-  '@tailwindcss/postcss@4.1.11':
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.1.11
       '@tailwindcss/oxide': 4.1.11
       postcss: 8.5.6

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,3 +1,3 @@
 module.exports = {
-  plugins: [require("@tailwindcss/postcss"), require("autoprefixer")],
+  plugins: [require('tailwindcss'), require('autoprefixer')],
 };


### PR DESCRIPTION
## Summary
- configure `postcss.config.cjs` to load Tailwind directly
- remove `@tailwindcss/postcss` from `package.json`
- prune the dependency from both lockfiles

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d3f8616cc832abbf4428c3122d1ca